### PR TITLE
Rocket Chat upgraded to Meteor 1.4.1.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN set -ex \
     gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
     done
 
-ENV NODE_VERSION 0.10.45
+ENV NODE_VERSION 4.5.0
 ENV NPM_VERSION 2.14.1
 
 RUN set -x \


### PR DESCRIPTION
> IMPORTANT: Upgraded to meteor 1.4.1.1 - Now uses NodeJS 4.5